### PR TITLE
fix(opnsense-ingress-operator): add CRD list permission to ClusterRole

### DIFF
--- a/charts/opnsense-ingress-operator/Chart.yaml
+++ b/charts/opnsense-ingress-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: opnsense-ingress-operator
 description: Kubernetes operator that syncs Ingress hostnames to OPNsense Unbound DNS host overrides
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: "v0.1.2"
 keywords:
   - opnsense

--- a/charts/opnsense-ingress-operator/templates/clusterrole.yaml
+++ b/charts/opnsense-ingress-operator/templates/clusterrole.yaml
@@ -17,3 +17,6 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch"]


### PR DESCRIPTION
## Summary

- Adds `apiextensions.k8s.io/customresourcedefinitions` `get/list/watch` to the `ClusterRole`
- Bumps chart version `0.1.2 → 0.1.3`
- kopf enumerates CRDs at startup to discover custom resources; without this rule the operator enters `CrashLoopBackOff` immediately after the v0.1.2 UID fix

Fixes singularcurio/opnsense-ingress-operator#2

> **Note:** This issue was filed against the operator repo but the fix is here in the helm-charts repo.

## Test plan

- [ ] Deploy chart 0.1.3 on a k3s cluster
- [ ] Confirm operator starts without `APIForbiddenError` in logs
- [ ] Confirm Ingress → Unbound DNS sync still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)